### PR TITLE
removing sponsored links from website list

### DIFF
--- a/find_the_site/fw.py
+++ b/find_the_site/fw.py
@@ -33,9 +33,9 @@ def get_website(query: str, eco: False) -> List[str]:
 
     if eco:
         site_list = [link["href"]
-                     for link in soup.findAll("a", {"class": "result-url js-result-url"})]
+                     for link in soup.findAll("a", {"class": "result-url js-result-url"}) if not 'duckduckgo.com/y.js' in link["href"]]
 
     else:
-        site_list = [link["href"] for link in soup.findAll("a", {"class": "result-link"})]
+        site_list = [link["href"] for link in soup.findAll("a", {"class": "result-link"}) if not 'duckduckgo.com/y.js' in link["href"]]
 
     return site_list


### PR DESCRIPTION
DDG Lite now returns sponsored links. This update removes ads and helps clean the links returned in the website list.
![sponsored-ad-ddg-lite](https://user-images.githubusercontent.com/25312138/77708544-bf1baf80-6f9e-11ea-8ca9-48ac11b83b25.png)


